### PR TITLE
Allow admins to filter by unapproved & deleted events

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ trim_trailing_whitespace = false
 
 [*.yml]
 indent_size = 2
+
+[*.vue]
+indent_size = 2

--- a/app/Event.php
+++ b/app/Event.php
@@ -19,6 +19,8 @@ class Event extends Model
         return [
             new Filters\Before,
             new Filters\After,
+            new Filters\Trashed,
+            new Filters\Unapproved,
         ];
     }
 

--- a/app/Filters/Unapproved.php
+++ b/app/Filters/Unapproved.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filters;
+
+use Illuminate\Http\Request;
+
+class Unapproved extends Filter
+{
+    /**
+     * Apply the filter to the given query.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  mixed  $value
+     */
+    public function apply(Request $request, $query, $value)
+    {
+        if ($value) {
+            $query->withoutGlobalScope('approved')->where('approved_at', null);
+        }
+    }
+}

--- a/resources/js/Pages/Events/Index.vue
+++ b/resources/js/Pages/Events/Index.vue
@@ -58,6 +58,33 @@
         </div>
       </div>
       <div class="hidden ml-8 xl:block">
+        <dropdown class="mb-4" placement="bottom-start" v-if="$page.auth.user && $page.auth.user.role === 'admin'">
+          <div class="flex items-center cursor-pointer select-none group">
+            <div
+              class="text-gray-800 group-hover:text-red-600 focus:text-red-600 mr-1 whitespace-no-wrap"
+            >
+              Filter Events
+            </div>
+            <icon
+              class="w-5 h-5 group-hover:fill-red-600 fill-gray-800 focus:fill-red-600"
+              name="cheveron-down"
+            />
+          </div>
+          <div slot="menu" class="mt-2 py-2 shadow-lg bg-white rounded text-sm">
+            <inertia-link
+              class="block px-6 py-2 hover:bg-gray-100"
+              :href="route('events.index')"
+              >All events</inertia-link>
+            <inertia-link
+              class="block px-6 py-2 hover:bg-gray-100"
+              :href="route('events.index', {trashed: 'only'})"
+              >Only trashed events</inertia-link>
+            <inertia-link
+              class="block px-6 py-2 hover:bg-gray-100"
+              :href="route('events.index', {unapproved: true})"
+              >Only unapproved events</inertia-link>
+          </div>
+        </dropdown>
         <calendar
           :value="form.after"
           @input="setAfter"
@@ -77,6 +104,8 @@ import LoadingButton from '@/Shared/LoadingButton'
 import { DateTime } from 'luxon'
 import InteractsWithDates from '@/mixins/InteractsWithDates'
 import { FORMAT_MYSQL } from '@/mixins/InteractsWithDates'
+import Dropdown from '@/Shared/Dropdown'
+import Icon from '@/Shared/Icon'
 
 export default {
   components: {
@@ -84,6 +113,8 @@ export default {
     Calendar,
     LoadingButton,
     FormattedTime,
+    Dropdown,
+    Icon
   },
 
   mixins: [InteractsWithDates],


### PR DESCRIPTION
I changed something about merging the array to the request. So I can omit the 'before' and 'after' filters if another filter is selected.

I noticed that not only admins can see the 'trashed' and 'unapproved' events. Is that intentional?
If not, I can also take a look at it and solve it in another PR. :)

I also changed how the query parameters are retrieved from the request. See also:
- https://github.com/laravel/ideas/issues/114
- https://github.com/laravel/framework/issues/13138
- https://github.com/laravel/docs/pull/2269

Cloeses #22 